### PR TITLE
Print correct package version from docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,4 @@ jobs:
 
       - name: Print package version
         run: |
-          docker run --rm \
-            ubuntu:latest \
-            -v scripts/version.sh:/version.sh \
-            bash /version.sh
+          docker run --rm -v $PWD/scripts/version.sh:/version.sh ubuntu:latest bash /version.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Print package version
         run: |
-          docker run --rm -v $PWD/scripts/version.sh:/version.sh ubuntu:latest bash /version.sh
+          docker run --rm -v "$PWD/scripts/version.sh:/version.sh" ubuntu:latest bash /version.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,5 @@ jobs:
         run: |
           docker run --rm \
             ubuntu:latest \
-            bash -c "echo \"$\(git --version\) $\(which git\)\" && \
-                     echo \"$\(docker -v\) $\(which docker\)\" && \
-                     echo \"node $\(node -v\) $\(which node\)\" && \
-                     echo \"$\(python --version\) $\(which python\)\" && \
-                     echo \"$\(go version\) $\(which go\)\" && \
-                     echo \"$\(rustc --version\) $\(which rustc\)\" && \
-                     echo \"npm $\(npm -v\) $\(which npm\)\" && \
-                     ansible --version && \
-                     ansible-lint --version"
+            -v scripts/version.sh:/version.sh \
+            bash /version.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,12 @@ jobs:
         run: |
           docker run --rm \
             ubuntu:latest \
-            bash -c "echo \"$(git --version) $(which git)\" && \
-                     echo \"$(docker -v) $(which docker)\" && \
-                     echo \"node $(node -v) $(which node)\" && \
-                     echo \"$(python --version) $(which python)\" && \
-                     echo \"$(go version) $(which go)\" && \
-                     echo \"$(rustc --version) $(which rustc)\" && \
-                     echo \"npm $(npm -v) $(which npm)\" && \
+            bash -c "echo \"$\(git --version\) $\(which git\)\" && \
+                     echo \"$\(docker -v\) $\(which docker\)\" && \
+                     echo \"node $\(node -v\) $\(which node\)\" && \
+                     echo \"$\(python --version\) $\(which python\)\" && \
+                     echo \"$\(go version\) $\(which go\)\" && \
+                     echo \"$\(rustc --version\) $\(which rustc\)\" && \
+                     echo \"npm $\(npm -v\) $\(which npm\)\" && \
                      ansible --version && \
                      ansible-lint --version"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "$(git --version) $(which git)"
+echo "$(docker -v) $(which docker)"
+echo "node $(node -v) $(which node)"
+echo "$(python --version) $(which python)"
+echo "$(go version) $(which go)"
+echo "$(rustc --version) $(which rustc)"
+echo "npm $(npm -v) $(which npm)"
+ansible --version
+ansible-lint --version


### PR DESCRIPTION
Previously, anything in `$(*)` gets substituted outside of docker before passing into docker image, so it's actually calling packages from GitHub's runner-image.