### PR TITLE
Pin Ubuntu major version per image directory in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,23 @@
   "extends": [
     "github>harryzcy/renovate-config"
   ],
+  "packageRules": [
+    {
+      "description": "Each images/ubuntu/<version> directory pins its own Ubuntu release; only digest updates are wanted",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ubuntu"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,8 +13,7 @@
       ],
       "matchUpdateTypes": [
         "major",
-        "minor",
-        "patch"
+        "minor"
       ],
       "enabled": false
     }


### PR DESCRIPTION
The shared `renovate-config` extends `config:best-practices`, which raises Docker tag updates for the `ubuntu` base image, producing PRs that rewrite `FROM ubuntu:22.04` and `24.04` to `26.04`. Each `images/ubuntu/<version>` directory is meant to track its own Ubuntu release, so disable `major` and `minor` updates for that dependency while keeping `digest` updates enabled.

`major` blocks `22.04` -> `26.04`; `minor` blocks `24.04` -> `24.10`, keeping an interim release out of a directory named for an LTS.